### PR TITLE
Enable document support by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,6 @@ Add this entry to your client's MCP settings JSON file:
       "env": {
         "CLICKUP_API_KEY": "your-api-key",
         "CLICKUP_TEAM_ID": "your-team-id",
-        "DOCUMENT_SUPPORT": "true"
       }
     }
   }
@@ -53,7 +52,7 @@ Or use this npx command:
 
 `npx -y @taazkareem/clickup-mcp-server@latest --env CLICKUP_API_KEY=your-api-key --env CLICKUP_TEAM_ID=your-team-id`
 
-**Obs: if you don't pass "DOCUMENT_SUPPORT": "true", the default is false and document support will not be active.**
+**Obs: document support is enabled by default. Set `DOCUMENT_SUPPORT` to `false` if you need to disable it.**
 
 Additionally, you can use the `DISABLED_TOOLS` environment variable or `--env DISABLED_TOOLS` argument to disable specific tools. Provide a comma-separated list of tool names to disable (e.g., `create_task,delete_task`).
 
@@ -103,7 +102,6 @@ services:
       - CLICKUP_TEAM_ID=${CLICKUP_TEAM_ID}
       - ENABLE_SSE=true
       - LOG_LEVEL=info
-      - DOCUMENT_SUPPORT=true
     volumes:
       - ./src:/app/src
     restart: unless-stopped

--- a/changelog.md
+++ b/changelog.md
@@ -30,7 +30,8 @@
   - Document listing and search across workspace
   - Document creation with customizable visibility
   - Document page management (create, list, get, update)
-  - Optional module activation via `DOCUMENT_SUPPORT=true` environment variable
+  - Document tools are enabled by default and can be disabled via the
+    `DOCUMENT_SUPPORT=false` environment variable
   - Support for both API V2 and V3 endpoints
 - Added comprehensive Time Tracking functionality:
   - View time entries for tasks with filtering options

--- a/examples/n8n/docker-compose.yml
+++ b/examples/n8n/docker-compose.yml
@@ -26,7 +26,6 @@ services:
       - CLICKUP_API_KEY=${CLICKUP_API_KEY}
       - CLICKUP_TEAM_ID=${CLICKUP_TEAM_ID}
       - ENABLE_SSE=true
-      - DOCUMENT_SUPPORT=true
     volumes:
       - ./src:/app/src
     restart: unless-stopped

--- a/src/config.ts
+++ b/src/config.ts
@@ -8,10 +8,11 @@
  * securely to this file when running the hosted server at smithery.ai. Optionally,
  * they can be parsed via command line arguments when running the server locally.
  *
- * The document support is optional and can be passed via command line arguments.
- * The default value is 'false' (string), which means document support will be disabled if
- * no parameter is passed. Pass it as 'true' (string) to enable it.
- */
+ * Document support can be toggled via the `DOCUMENT_SUPPORT` environment
+ * variable or command line argument. By default the feature is enabled.
+ * Set the value to 'false' (string) to disable document tools when launching
+ * the server.
+*/
 
 // Parse any command line environment arguments
 const args = process.argv.slice(2);
@@ -85,7 +86,7 @@ const configuration: Config = {
     process.env.DOCUMENT_SUPPORT ||
     process.env.DOCUMENT_MODULE ||
     process.env.DOCUMENT_MODEL ||
-    'false',
+    'true',
   logLevel: parseLogLevel(envArgs.logLevel || process.env.LOG_LEVEL),
   disabledTools:
     (envArgs.disabledTools || process.env.DISABLED_TOOLS || process.env.DISABLED_COMMANDS)


### PR DESCRIPTION
## Summary
- document tools no longer require DOCUMENT_SUPPORT=true to enable
- update docs and example docker-compose

## Testing
- `npm run build` *(fails: Cannot find type declarations)*

------
https://chatgpt.com/codex/tasks/task_b_68420a1170a4832eb05b665bf4605dbd