### PR TITLE
Fix parent_type in document listing

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -988,6 +988,7 @@ Add the "feature" tag to the task "Implement Authentication"
   - List (6)
   - All (7)
   - Workspace (12)
+  - For `list_documents`, use lowercase values (`space`, `folder`, `list`)
 
 - **Visibility Settings**:
   - PUBLIC: Document is visible to all workspace members

--- a/src/tools/documents.ts
+++ b/src/tools/documents.ts
@@ -110,8 +110,8 @@ export const listDocumentsTool = {
       },
       parent_type: {
         type: "string",
-        enum: ["TASK", "SPACE", "FOLDER", "LIST", "EVERYTHING", "WORKSPACE"],
-        description: "Type of the parent container"
+        enum: ["space", "folder", "list"],
+        description: "Type of the parent container (space, folder, or list)"
       },
       limit: {
         type: "number",
@@ -385,7 +385,13 @@ export async function handleListDocuments(parameters: any) {
     if (deleted !== undefined) options.deleted = deleted;
     if (archived !== undefined) options.archived = archived;
     if (parent_id !== undefined) options.parent_id = parent_id;
-    if (parent_type !== undefined) options.parent_type = parent_type;
+    if (parent_type !== undefined) {
+      const normalized = String(parent_type).toLowerCase();
+      const allowed = ["space", "folder", "list"];
+      if (allowed.includes(normalized)) {
+        options.parent_type = normalized;
+      }
+    }
     if (limit !== undefined) options.limit = limit;
     if (next_cursor !== undefined) options.next_cursor = next_cursor;
 


### PR DESCRIPTION
## Summary
- correct `parent_type` in `list_documents` schema
- normalize `parent_type` when listing documents
- document required lowercase parent type values

## Testing
- `npm run build` *(fails: Cannot find module and type errors)*

------
https://chatgpt.com/codex/tasks/task_b_68421a791a70832eaa2f9a9b40872f49