### PR TITLE
Add parent_type note for list_documents

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,13 +170,15 @@ services:
 | [resolve_assignees](docs/api-reference.md#member-management)          | Resolve member names to IDs     | `assignees[]`                                                                                                              |
 | [create_document](docs/api-reference.md#document-management)          | Create a document               | `workspaceId`, `name`, `parentId`/`parentType`, `visibility`, `create_pages`                                     |
 | [get_document](docs/api-reference.md#document-management)             | Get a document                  | `workspaceId`/`documentId`                                                                                               |
-| [list_documents](docs/api-reference.md#document-management)           | List documents                  | `workspaceId`, `documentId`/`creator`/`deleted`/`archived`/`parent_id`/`parent_type`/`limit`/`next_cursor` |
+| [list_documents](docs/api-reference.md#document-management)           | List documents                  | `workspaceId`, `documentId`/`creator`/`deleted`/`archived`/`parent_id`/`parent_type`/`limit`/`next_cursor`[^parent-type-note] |
 | [list_document_pages](docs/api-reference.md#document-management)      | List document pages             | `documentId`/`documentName`                                                                                              |
 | [get_document_pages](docs/api-reference.md#document-management)       | Get document pages              | `documentId`/`documentName`, `pageIds`                                                                                 |
 | [create_document_pages](docs/api-reference.md#document-management)    | Create a document page          | `workspaceId`/`documentId`, `parent_page_id`/`name`/`sub_title`,`content`/`content_format`                     |
 | [update_document_page](docs/api-reference.md#document-management)     | Update a document page          | `workspaceId`/`documentId`, `name`/`sub_title`,`content`/`content_edit_mode`/`content_format`                  |
 
 See [full documentation](docs/api-reference.md) for optional parameters and advanced usage.
+
+[^parent-type-note]: `parent_type` must be lowercase (`space`, `folder`, `list`).
 
 ## Member Management Tools
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -974,7 +974,7 @@ Add the "feature" tag to the task "Implement Authentication"
 |------|-------------|-------------------|-------------------|
 | create_document | Create a document | `name`, `parent` (with `id` and `type`), `visibility`, `create_page` | None |
 | get_document | Get document details | `documentId` | None |
-| list_documents | List documents | None | `id`, `creator`, `deleted`, `archived`, `parent_id`, `parent_type`, `limit`, `next_cursor` |
+| list_documents | List documents | None | `id`, `creator`, `deleted`, `archived`, `parent_id`, `parent_type`, `limit`, `next_cursor`[^parent-type-note] |
 | list_document_pages | List document pages | `documentId` | `max_page_depth` (-1 for unlimited) |
 | get_document_pages | Get document pages | `documentId`, `pageIds` | `content_format` ('text/md'/'text/html') |
 | create_document_page | Create a document page | `documentId`, `name` | `content`, `sub_title`, `parent_page_id` |
@@ -988,6 +988,8 @@ Add the "feature" tag to the task "Implement Authentication"
   - List (6)
   - All (7)
   - Workspace (12)
+
+[^parent-type-note]: `parent_type` must be lowercase (`space`, `folder`, `list`).
 
 - **Visibility Settings**:
   - PUBLIC: Document is visible to all workspace members


### PR DESCRIPTION
## Summary
- clarify that `parent_type` for `list_documents` must be lowercase

## Testing
- `npm run build` *(fails: Cannot find name 'process' and missing modules)*

------
https://chatgpt.com/codex/tasks/task_b_68421c50d054832ea1ab08cab894fac5