### PR TITLE
Fix parent_type documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ services:
 
 See [full documentation](docs/api-reference.md) for optional parameters and advanced usage.
 
-[^parent-type-note]: `parent_type` must be lowercase (`space`, `folder`, `list`).
+[^parent-type-note]: Valid values for `parent_type` are `SPACE`, `FOLDER`, `LIST`, `EVERYTHING`, and `WORKSPACE` (case-insensitive).
 
 ## Member Management Tools
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -988,6 +988,7 @@ Add the "feature" tag to the task "Implement Authentication"
   - LIST (6)
   - EVERYTHING (7)
   - WORKSPACE (12)
+  - Use these names for the `parent_type` parameter when listing documents (case-insensitive)
 
 - **Visibility Settings**:
   - public: Document is visible to all workspace members

--- a/src/services/clickup/types.ts
+++ b/src/services/clickup/types.ts
@@ -583,7 +583,7 @@ export interface ListDocumentsOptions {
   deleted?: boolean;
   archived?: boolean;
   parent_id?: string;
-  parent_type?: 'space' | 'folder' | 'list';
+  parent_type?: 'space' | 'folder' | 'list' | 'everything' | 'workspace';
   limit?: number;
   next_cursor?: string;
 }

--- a/src/tools/documents.ts
+++ b/src/tools/documents.ts
@@ -23,7 +23,7 @@ const { document: documentService } = clickUpServices;
  */
 export const createDocumentTool = {
   name: "create_document",
-  description: `Creates a document in a ClickUp space, folder, or list. Requires name, parent info, visibility and create_page flag.`,
+  description: `Creates a document in a ClickUp space, folder, list, everything, or workspace. Parent.type uses numeric codes (4=SPACE, 5=FOLDER, 6=LIST, 7=EVERYTHING, 12=WORKSPACE). Requires name, parent info, visibility and create_page flag.`,
   inputSchema: {
     type: "object",
     properties: {
@@ -84,7 +84,7 @@ export const getDocumentTool = {
  */
 export const listDocumentsTool = {
   name: "list_documents",
-  description: `Lists all documents in a ClickUp space, folder, or list.`,
+  description: `Lists documents across containers. The parent_type filter accepts SPACE, FOLDER, LIST, EVERYTHING or WORKSPACE (case-insensitive).`,
   inputSchema: {
     type: "object",
     properties: {


### PR DESCRIPTION
## Summary
- document numeric parent type codes in tool description
- explain valid parent_type values in README and docs
- update list_documents description to list all enums
- widen `ListDocumentsOptions.parent_type` to include `everything` and `workspace`

## Testing
- `npm run build` *(fails: Cannot find module type definitions)*

------
https://chatgpt.com/codex/tasks/task_b_68422cfc25c4832eba2ca522989ba6fd